### PR TITLE
Fix the bug of issue #37

### DIFF
--- a/templates/extractV8Value.def
+++ b/templates/extractV8Value.def
@@ -10,7 +10,7 @@ var convertIDLType2ExtractMacro = function (idlType, refTypeMap, callback) {
   type = type.replace('std::', '');
   if (isCallback(idlType, callback)) {
     type = 'function';
-  } else if (isInterface(idlType, refTypeMap) || isDictionary(idlType, refTypeMap)) {
+  } else if ((isInterface(idlType, refTypeMap) || isDictionary(idlType, refTypeMap)) && !isArray(idlType)) {
     type = 'object';
   } else if (type === 'v8::Local<v8::Array>') {
     type = 'array';

--- a/templates/implHeaderProperty.def
+++ b/templates/implHeaderProperty.def
@@ -11,6 +11,10 @@ if (isInterface(p.idlType, it.refTypeMap)) {
   addrStr = '&';
   ptrStr = '*';
 }
+if (isArray(p.idlType, it.refTypeMap)) {
+  addrStr = '';
+  ptrStr = '';
+}
 }}
 
   {{=propertyType}}{{=ptrStr}} get_{{=p.name}}() const {

--- a/templates/nanCxxImplProperty.def
+++ b/templates/nanCxxImplProperty.def
@@ -46,7 +46,9 @@ NAN_GETTER({{=className}}::{{=p.name}}Getter) {
   } else {
     // TODO: modify nanCxxImplProperty.def to handle this case
   }
-{{?? isInterface(p.idlType, it.refTypeMap)}}
+
+
+{{?? isInterface(p.idlType, it.refTypeMap) && !isArray(p.idlType)}}
 {{ var retType = p.idlType.idlType; }}
   if (! {{=myself}}{{=p.name}}_) {
     {{=myself}}{{=p.name}}_.reset(new Nan::Persistent<v8::Object>(Nan{{=retType}}::NewInstance()));
@@ -86,7 +88,7 @@ NAN_SETTER({{=className}}::{{=p.name}}Setter) {
   } else {
     // TODO: modify nanCxxImplProperty.def to handle this case
   }
-{{?? isInterface(p.idlType, it.refTypeMap)}}
+{{?? isInterface(p.idlType, it.refTypeMap) && !isArray(p.idlType)}}
   // Extract data from the JavaScript object
   // First, convert to impl {{=p.idlType.idlType}} pointer
   auto impl_value = *(ObjectWrap::Unwrap<Nan{{=p.idlType.idlType}}>(v8_value)->{{=generateGetImplMethodName(p.idlType.idlType)}}());

--- a/test/array/addon.cpp
+++ b/test/array/addon.cpp
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 #include "gen/nan__canvas.h"
+#include "gen/nan__point.h"
 
 void initModule(v8::Local<v8::Object> exports) {
   NanCanvas::Init(exports);
+  Nanpoint::Init(exports);
 }
 
 NODE_MODULE(testAttributes, initModule);

--- a/test/array/array.widl
+++ b/test/array/array.widl
@@ -5,10 +5,18 @@
 [
 Constructor
 ]
+interface point {
+    attribute long x;
+    attribute long y;
+};
+
+[
+Constructor
+]
 interface Canvas {
   attribute double[] coordinates;
   attribute DOMString[] codecs;
-
+  attribute point[] points;
   sequence<DOMString> getSupportedImageCodecs();
 
   void drawPolygon(sequence<double> coordinates);

--- a/test/array/binding.gyp
+++ b/test/array/binding.gyp
@@ -7,7 +7,9 @@
       "sources": [
         "addon.cpp",
         "gen/nan__canvas.cpp",
+        "gen/nan__point.cpp",
         "canvas.cpp",
+        "point.cpp"
       ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")",

--- a/test/array/canvas.h
+++ b/test/array/canvas.h
@@ -14,6 +14,8 @@
 #include "gen/generator_helper.h"
 #include "gen/array_helper.h"
 
+#include "point.h"
+
 class Canvas {
  public:
   Canvas();
@@ -40,6 +42,14 @@ class Canvas {
     this->codecs_ = new_value;
   }
 
+  ArrayHelper get_points() const {
+    return this->points_;
+  }
+
+  void set_points(const ArrayHelper& new_value) {
+    this->points_ = new_value;
+  }
+
   ArrayHelper getSupportedImageCodecs();
 
   void drawPolygon(const ArrayHelper& coordinates);
@@ -54,6 +64,7 @@ class Canvas {
  private:
   ArrayHelperStorage coordinates_;
   ArrayHelperStorage codecs_;
+  mutable ArrayHelperStorage points_;
   std::vector<double> array_;
 };
 

--- a/test/array/point.cpp
+++ b/test/array/point.cpp
@@ -1,0 +1,21 @@
+// To add your copyright and license header
+
+#include "point.h"
+
+point::point() {
+  // TODO(widl-nan): init your members
+  x_ = 0;
+  y_ = 0;
+}
+
+point::~point() {
+  // TODO(widl-nan): do cleanup if necessary
+}
+
+point& point::operator = (const point& rhs) {
+  if (&rhs != this) {
+    // TODO(widl-nan): copy members from rhs
+  }
+  return *this;
+}
+

--- a/test/array/point.h
+++ b/test/array/point.h
@@ -1,0 +1,50 @@
+// To add your copyright and license header
+
+#ifndef _POINT_H_
+#define _POINT_H_
+
+#include <node.h>
+#include <v8.h>
+
+#include <string>
+
+#include "gen/generator_helper.h"
+#include "gen/array_helper.h"
+
+class point {
+ public:
+  point();
+
+  ~point();
+
+  point& operator = (const point& rhs);
+
+ public:
+  int32_t get_x() const {
+    return this->x_;
+  }
+
+  void set_x(const int32_t& new_value) {
+    this->x_ = new_value;
+  }
+
+  int32_t get_y() const {
+    return this->y_;
+  }
+
+  void set_y(const int32_t& new_value) {
+    this->y_ = new_value;
+  }
+
+  void SetJavaScriptThis(v8::Local<v8::Object> obj) {
+    // Ignore this if you don't need it
+    // Typical usage: emit an event on `obj`
+  }
+
+ private:
+  int32_t x_;
+
+  int32_t y_;
+};
+
+#endif  // _POINT_H_

--- a/test/test-array.js
+++ b/test/test-array.js
@@ -11,7 +11,7 @@ var compile = require('../lib/compile.js').compile;
 var path = require('path');
 
 var Canvas = null;
-
+var point = null;
 describe('widl-nan Unit Test - sequence<T> as Array', function() {
   it('Generating binding C++ code', function() {
     return compile('test/array/array.widl', 'test/array/gen');
@@ -30,6 +30,7 @@ describe('widl-nan Unit Test - sequence<T> as Array', function() {
         // eslint-disable-next-line camelcase
         {bindings: 'widlNanAddon', module_root: addonDir});
     Canvas = addon.Canvas;
+    point = addon.point;
     assert.equal(typeof Canvas, 'function');
   });
 
@@ -48,6 +49,22 @@ describe('widl-nan Unit Test - sequence<T> as Array', function() {
     assert.equal(x.codecs[1], 'png');
     assert.equal(x.codecs[2], 'tif');
     assert.equal(x.codecs[3], 'gif');
+
+    var p1 = new point();
+    var p2 = new point();
+    p1.x = 1;
+    p1.y = 2;
+    p2.x = 2;
+    p2.y = 3;
+    x.points = [];
+    x.points.push(p1);
+    x.points.push(p2);
+
+    assert.equal(x.points.length,2);
+    assert.equal(x.points[0].x, 1);
+    assert.equal(x.points[0].y, 2);
+    assert.equal(x.points[1].x, 2);
+    assert.equal(x.points[1].y, 3);
 
     done();
   });


### PR DESCRIPTION
The generated getter method doesn't need to create nan__xxx
instances for interface array attribute, only need to get the array
from impl and set it as return value. Add checks to separate interface
and interface array attributes, and also update ut tests.
@kenny-y 
