### PR TITLE
Closes #51

### DIFF
--- a/templates/nanCxxImplProperty.def
+++ b/templates/nanCxxImplProperty.def
@@ -65,6 +65,11 @@ NAN_GETTER({{=className}}::{{=p.name}}Getter) {
   info.GetReturnValue().Set(static_cast<v8::Local<v8::Object>>(impl_val));
 {{?? isArray(p.idlType) }}
   info.GetReturnValue().Set(static_cast<v8::Local<v8::Array>>(impl_val));
+{{?? p.idlType.idlType === 'ArrayBuffer' }}
+  v8::Local<v8::Object> value;
+  if (Nan::NewBuffer(impl_val.data, impl_val.size).ToLocal(&value)) {
+    info.GetReturnValue().Set(value);
+  }
 {{?? true}}
   info.GetReturnValue().Set(Nan::New(impl_val){{=str}});
 {{?}}

--- a/test/buffer/buffer.cpp
+++ b/test/buffer/buffer.cpp
@@ -12,12 +12,12 @@ Buffer::Buffer() {
 Buffer::~Buffer() {
 }
 
-ArrayBuffer Buffer::getArrayBuffer() {
+ArrayBuffer Buffer::getArrayBuffer() const {
   const char* text = "hello world!";
 
   uint32_t size = strlen(text);
   // Use malloc to allocate memory for node array buffer.
-  char* buf = (char*)malloc(size);
+  char* buf = reinterpret_cast<char*>(malloc(size));
   memcpy(buf, text, size);
 
   ArrayBuffer arrayBuffer;

--- a/test/buffer/buffer.h
+++ b/test/buffer/buffer.h
@@ -18,11 +18,21 @@ class Buffer {
   ~Buffer();
 
  public:
-  ArrayBuffer getArrayBuffer();
+  ArrayBuffer getArrayBuffer() const;
+
+  ArrayBuffer get_data() const {
+    return getArrayBuffer();
+  }
+
+  void set_data(const ArrayBuffer& new_value) {
+  }
 
   std::string buffer2String(const ArrayBuffer& arrayBuffer) {
     return std::string(arrayBuffer.data, arrayBuffer.size);
   }
+
+ private:
+  ArrayBuffer data_;
 };
 
 #endif  // _BUFFER_H_

--- a/test/buffer/buffer.widl
+++ b/test/buffer/buffer.widl
@@ -4,6 +4,7 @@
 
 [Constructor]
 interface Buffer {
+  attribute ArrayBuffer data;
   ArrayBuffer getArrayBuffer();
 
   DOMString buffer2String(ArrayBuffer buffer);

--- a/test/test-buffer.js
+++ b/test/test-buffer.js
@@ -38,14 +38,20 @@ describe('widl-nan Unit Test - Buffer', function() {
 
   it('Method returning an ArrayBuffer', done => {
     var bufferTest = new BufferTest();
-    assert.equal(bufferTest.getArrayBuffer().toString(), "hello world!");
+    assert.equal(bufferTest.getArrayBuffer().toString(), 'hello world!');
+    done();
+  });
+
+  it('Object property as ArrayBuffer', done => {
+    var bufferTest = new BufferTest();
+    assert.equal(bufferTest.data.toString(), 'hello world!');
     done();
   });
 
   it('Passing ArrayBuffer as paramter', done => {
-     var bufferTest = new BufferTest();
-     const buffer = new Buffer('This is node Buffer');
-     assert.equal(bufferTest.buffer2String(buffer), 'This is node Buffer');
-     done();
-   });
+    var bufferTest = new BufferTest();
+    const buffer = new Buffer('This is node Buffer');
+    assert.equal(bufferTest.buffer2String(buffer), 'This is node Buffer');
+    done();
+  });
 });


### PR DESCRIPTION
After this PR, ArrayBuffer can be used as the type of object property (declared by attribute keyword)