### PR TITLE
No longer requires IDL [Constructor] notation to enable constructing …

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,6 +303,8 @@ const widl2NanGenerator = function() {
                         _packEmptyLines(dots.helperHeaderThreadEvent({}))));
     all.push(_writeFile(path.join(dirName, 'thread-event-helper.cpp'),
                         _packEmptyLines(dots.helperHeaderThreadEventCpp({}))));
+    all.push(_writeFile(path.join(dirName, 'widlnan_internal_raii_helper.h'),
+                        _packEmptyLines(dots.helperHeaderRAII({}))));
     all.push(_writeFile(path.join(dirNameSkeleton, 'addon.cpp'),
                         _packEmptyLines(dots.addonCpp(this))));
     all.push(_writeFile(path.join(dirNameSkeleton, 'binding.gyp'),

--- a/templates/helperHeader.dot
+++ b/templates/helperHeader.dot
@@ -5,6 +5,8 @@
 #include <memory>
 #include <limits>
 
+#include "widlnan_internal_raii_helper.h"
+
 #define EXTRACT_v8_String(x) EXTRACT_v8_string(x)
 #define EXTRACT_v8_float(x) EXTRACT_v8_double(x)
 

--- a/templates/helperHeaderRAII.dot
+++ b/templates/helperHeaderRAII.dot
@@ -1,0 +1,13 @@
+#ifndef _WIDLNAN_INTERNAL_RAII_HELPER_H_
+#define _WIDLNAN_INTERNAL_RAII_HELPER_H_
+
+class NewInstanceInternalFlagGuard {
+public:
+  explicit NewInstanceInternalFlagGuard(bool &flag) : flag_(flag) { flag_ = true; }
+  ~NewInstanceInternalFlagGuard() { flag_ = false; }
+
+ private:
+  bool & flag_;
+};
+
+#endif // _WIDLNAN_INTERNAL_RAII_HELPER_H_

--- a/templates/nanCxxHeader.dot
+++ b/templates/nanCxxHeader.dot
@@ -55,6 +55,8 @@ class {{=nanClassName}} : public Nan::ObjectWrap {
 
   static Nan::Persistent<v8::Function> constructor;
 
+  static bool internal_ctor_call_once_;  // Calling JavaScript new in C++
+
 {{? useImpl}}
  private:
   {{=implClassName}}* impl_;

--- a/templates/nanCxxImpl.dot
+++ b/templates/nanCxxImpl.dot
@@ -29,6 +29,8 @@
 
 Nan::Persistent<v8::Function> Nan{{=it.name}}::constructor;
 
+bool Nan{{=it.name}}::internal_ctor_call_once_;  // Calling JavaScript new in C++
+
 {{#def.nanCxxImplPropertyVarsDef}}
 
 {{? useImpl}}
@@ -86,11 +88,7 @@ void Nan{{=it.name}}::Init(v8::Local<v8::Object> exports) {
 
 v8::Local<v8::Object> Nan{{=it.name}}::NewInstance(int argc, v8::Local<v8::Value> argv[])
 {
-  static v8::Local<v8::Value> emptyArgv[0] = {};
-
-  if (argc == 0) {
-    argv = emptyArgv;
-  }
+  NewInstanceInternalFlagGuard guard(Nan{{=it.name}}::internal_ctor_call_once_);
 
   v8::Local<v8::Function> cons = Nan::New<v8::Function>(Nan{{=it.name}}::constructor);
   v8::Local<v8::Context> context = v8::Isolate::GetCurrent()->GetCurrentContext();
@@ -101,13 +99,12 @@ v8::Local<v8::Object> Nan{{=it.name}}::NewInstance(int argc, v8::Local<v8::Value
 {{? useImpl}}
 v8::Local<v8::Object> Nan{{=it.name}}::NewInstance({{=it.name}}* implPtr, bool ownPtr)
 {
-  static v8::Local<v8::Value> emptyArgv[0] = {};
-  static int argc0 = 0;
+  NewInstanceInternalFlagGuard guard(Nan{{=it.name}}::internal_ctor_call_once_);
 
   v8::Local<v8::Function> cons = Nan::New<v8::Function>(Nan{{=it.name}}::constructor);
   v8::Local<v8::Context> context = v8::Isolate::GetCurrent()->GetCurrentContext();
 
-  v8::Local<v8::Object> ret = cons->NewInstance(context, argc0, emptyArgv).ToLocalChecked();
+  v8::Local<v8::Object> ret = cons->NewInstance(context, 0, nullptr).ToLocalChecked();
   auto wrapper = Nan::ObjectWrap::Unwrap<Nan{{=it.name}}>(ret);
   delete wrapper->impl_;
   wrapper->impl_ = implPtr;
@@ -139,23 +136,38 @@ NAN_METHOD(Nan{{=it.name}}::New) {
     }
 {{~}}
     else {
-      Nan::ThrowTypeError("Illegal constructor");
+      if ( internal_ctor_call_once_ ) {
+{{? useImpl}}
+        obj->impl_ = new {{=it.name}}();
+{{?}}
+        internal_ctor_call_once_ = false;
+      } else {
+        Nan::ThrowTypeError("Illegal constructor");
+      }
     }
 
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
 
 {{?? true}}
-    Nan::ThrowTypeError("Illegal constructor");
+    if ( internal_ctor_call_once_ ) {
+      Nan{{=it.name}}* obj = new Nan{{=it.name}}();
+{{? useImpl}}
+      obj->impl_ = new {{=it.name}}();
+{{?}}
+      internal_ctor_call_once_ = false;
+      obj->Wrap(info.This());
+      info.GetReturnValue().Set(info.This());
+    } else {
+      Nan::ThrowTypeError("Illegal constructor");
+    }
 {{?}}
 
   } else {
     // Invoked as plain function `Nan{{=it.name}}()`, turn into construct call.
-    const int argc = 0;
-    v8::Local<v8::Value> argv[argc] = {};
     v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    v8::Local<v8::Object> instance = cons->NewInstance(context, argc, argv).ToLocalChecked();
+    v8::Local<v8::Object> instance = cons->NewInstance(context).ToLocalChecked();
     info.GetReturnValue().Set(instance);
   }
 }

--- a/test/constructor/binding.gyp
+++ b/test/constructor/binding.gyp
@@ -9,6 +9,7 @@
       "sources": [
         "addon.cpp",
         "container_class.cpp",
+        "no_constructor_class.cpp",
         "gen/nan__container_class.cpp",
         "gen/nan__my_class.cpp",
         "gen/nan__no_constructor_class.cpp",

--- a/test/constructor/constructor.widl
+++ b/test/constructor/constructor.widl
@@ -14,6 +14,7 @@ interface MyClass {
 };
 
 interface NoConstructorClass {
+  attribute long counter;
 };
 
 [
@@ -24,4 +25,6 @@ Constructor(double diameter, MyClass obj)
 interface ContainerClass {
   readonly attribute MyClass embedded;
   readonly attribute double diameter;
+
+  NoConstructorClass createNoConstructorClassObject();
 };

--- a/test/constructor/container_class.cpp
+++ b/test/constructor/container_class.cpp
@@ -28,3 +28,8 @@ ContainerClass& ContainerClass::operator = (const ContainerClass& rhs) {
   }
   return *this;
 }
+
+NoConstructorClass* ContainerClass::createNoConstructorClassObject() {
+  return new NoConstructorClass();
+}
+

--- a/test/constructor/container_class.h
+++ b/test/constructor/container_class.h
@@ -14,6 +14,8 @@
 
 #include "my_class.h"
 
+#include "no_constructor_class.h"
+
 class ContainerClass {
  public:
   ContainerClass();
@@ -34,6 +36,8 @@ class ContainerClass {
   double get_diameter() const {
     return this->diameter_;
   }
+
+  NoConstructorClass* createNoConstructorClassObject();
 
   void SetJavaScriptThis(v8::Local<v8::Object> obj) {
     // Ignore this if you don't need it

--- a/test/constructor/no_constructor_class.cpp
+++ b/test/constructor/no_constructor_class.cpp
@@ -1,0 +1,23 @@
+// To add your copyright and license header
+
+#include "no_constructor_class.h"
+
+NoConstructorClass::NoConstructorClass() {
+  counter_ = 0;
+}
+
+NoConstructorClass::NoConstructorClass(const NoConstructorClass& rhs) {
+  counter_ = rhs.counter_;
+}
+
+NoConstructorClass::~NoConstructorClass() {
+}
+
+NoConstructorClass& NoConstructorClass::operator = (
+    const NoConstructorClass& rhs) {
+  if (&rhs != this) {
+    counter_ = rhs.counter_;
+  }
+  return *this;
+}
+

--- a/test/constructor/no_constructor_class.h
+++ b/test/constructor/no_constructor_class.h
@@ -1,0 +1,42 @@
+// To add your copyright and license header
+
+#ifndef _NO_CONSTRUCTOR_CLASS_H_
+#define _NO_CONSTRUCTOR_CLASS_H_
+
+#include <node.h>
+#include <v8.h>
+
+#include <string>
+
+#include "gen/generator_helper.h"
+#include "gen/array_helper.h"
+
+class NoConstructorClass {
+ public:
+  NoConstructorClass();
+
+  NoConstructorClass(const NoConstructorClass& rhs);
+
+  ~NoConstructorClass();
+
+  NoConstructorClass& operator = (const NoConstructorClass& rhs);
+
+ public:
+  int32_t get_counter() const {
+    return this->counter_;
+  }
+
+  void set_counter(const int32_t& new_value) {
+    this->counter_ = new_value;
+  }
+
+  void SetJavaScriptThis(v8::Local<v8::Object> obj) {
+    // Ignore this if you don't need it
+    // Typical usage: emit an event on `obj`
+  }
+
+ private:
+  int32_t counter_;
+};
+
+#endif  // _NO_CONSTRUCTOR_CLASS_H_

--- a/test/test-constructor.js
+++ b/test/test-constructor.js
@@ -80,4 +80,13 @@ describe('widl-nan Unit Test - Constructor', function() {
     assert.equal(y.embedded.radius, 3128);
     done();
   });
+
+  it('Test object of a no constructor class', done => {
+    var x = new ContainerClass();
+    var obj = x.createNoConstructorClassObject();
+    obj.counter = 12355;
+    assert.equal(obj.counter, 12355);
+
+    done();
+  });
 });


### PR DESCRIPTION
…an JS object in C++

Fix #62