### PR TITLE
Fix issue #68 remove unnecessary constructor calling

### DIFF
--- a/templates/nanCxxImpl.dot
+++ b/templates/nanCxxImpl.dot
@@ -136,14 +136,7 @@ NAN_METHOD(Nan{{=it.name}}::New) {
     }
 {{~}}
     else {
-      if ( internal_ctor_call_once_ ) {
-{{? useImpl}}
-        obj->impl_ = new {{=it.name}}();
-{{?}}
-        internal_ctor_call_once_ = false;
-      } else {
         Nan::ThrowTypeError("Illegal constructor");
-      }
     }
 
     obj->Wrap(info.This());

--- a/test/constructor/addon.cpp
+++ b/test/constructor/addon.cpp
@@ -4,10 +4,12 @@
 
 #include "gen/nan__container_class.h"
 #include "gen/nan__my_class.h"
+#include "gen/nan__my_class2.h"
 #include "gen/nan__no_constructor_class.h"
 
 void initModule(v8::Local<v8::Object> exports) {
   NanMyClass::Init(exports);
+  NanMyClass2::Init(exports);
 
   NanNoConstructorClass::Init(exports);
 

--- a/test/constructor/binding.gyp
+++ b/test/constructor/binding.gyp
@@ -12,8 +12,10 @@
         "no_constructor_class.cpp",
         "gen/nan__container_class.cpp",
         "gen/nan__my_class.cpp",
+        "gen/nan__my_class2.cpp",
         "gen/nan__no_constructor_class.cpp",
         "my_class.cpp",
+        "my_class2.cpp",
       ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")",

--- a/test/constructor/constructor.widl
+++ b/test/constructor/constructor.widl
@@ -28,3 +28,10 @@ interface ContainerClass {
 
   NoConstructorClass createNoConstructorClassObject();
 };
+
+[
+Constructor(long val)
+]
+interface MyClass2 {
+    readonly attribute long value;
+};

--- a/test/constructor/my_class2.cpp
+++ b/test/constructor/my_class2.cpp
@@ -1,0 +1,24 @@
+// To add your copyright and license header
+
+#include "my_class2.h"
+
+MyClass2::MyClass2(const int32_t& val) {
+    value_ = val;
+}
+
+MyClass2::MyClass2(const MyClass2& rhs) {
+  // TODO(widl-nan): copy from rhs if you want this behavior
+  // Or mark ctor = delete in my_class2.h
+}
+
+MyClass2::~MyClass2() {
+  // TODO(widl-nan): do cleanup if necessary
+}
+
+MyClass2& MyClass2::operator = (const MyClass2& rhs) {
+  if (&rhs != this) {
+    // TODO(widl-nan): copy members from rhs
+  }
+  return *this;
+}
+

--- a/test/constructor/my_class2.h
+++ b/test/constructor/my_class2.h
@@ -1,0 +1,38 @@
+// To add your copyright and license header
+
+#ifndef _MY_CLASS2_H_
+#define _MY_CLASS2_H_
+
+#include <node.h>
+#include <v8.h>
+
+#include <string>
+
+#include "gen/generator_helper.h"
+#include "gen/array_helper.h"
+
+class MyClass2 {
+ public:
+  explicit MyClass2(const int32_t& val);
+
+  MyClass2(const MyClass2& rhs);
+
+  ~MyClass2();
+
+  MyClass2& operator = (const MyClass2& rhs);
+
+ public:
+  int32_t get_value() const {
+    return this->value_;
+  }
+
+  void SetJavaScriptThis(v8::Local<v8::Object> obj) {
+    // Ignore this if you don't need it
+    // Typical usage: emit an event on `obj`
+  }
+
+ private:
+  int32_t value_;
+};
+
+#endif  // _MY_CLASS2_H_

--- a/test/test-constructor.js
+++ b/test/test-constructor.js
@@ -11,6 +11,7 @@ var compile = require('../lib/compile.js').compile;
 var path = require('path');
 
 var MyClass = null;
+var MyClass2 = null;
 var NoConstructorClass = null;
 var ContainerClass = null;
 
@@ -32,6 +33,7 @@ describe('widl-nan Unit Test - Constructor', function() {
         // eslint-disable-next-line camelcase
         {bindings: 'widlNanAddon', module_root: addonDir});
     MyClass = addon.MyClass;
+    MyClass2 = addon.MyClass2;
     assert.equal(typeof MyClass, 'function');
 
     NoConstructorClass = addon.NoConstructorClass;
@@ -52,6 +54,12 @@ describe('widl-nan Unit Test - Constructor', function() {
     var x = new MyClass(64);
     assert.equal(x.url, '');
     assert.equal(x.radius, 64);
+    done();
+  });
+
+  it('Test only has one constructor with 1 parameter', done => {
+    var x = new MyClass2(100);
+    assert.equal(x.value, 100);
     done();
   });
 


### PR DESCRIPTION
@kenny-y  please help to review this. Because it removes some code related to constructor calling which you added for another bug, I'm not a bit confident with the impact. Thanks.

when interface are defined as
[
Constructor(long val)
]
interface MyClass {
     attribute readonly long value;
};

there will be compile error, because the generated nan__xxx file calls new MyClass() but there is no
default constructor for MyClass generated.
