### PR TITLE
fix issue #72 ArrayBuffer object freed mutiple times when garbage col…

### DIFF
--- a/templates/nanCxxHeaderPropertyVars.def
+++ b/templates/nanCxxHeaderPropertyVars.def
@@ -8,7 +8,7 @@ if (p.static) {
   staticStr = 'static ';
 }
 }}
-{{? isInterface(p.idlType, it.refTypeMap) }}
+{{? isInterface(p.idlType, it.refTypeMap) || (p.idlType.idlType == 'ArrayBuffer') }}
   {{=staticStr}}std::unique_ptr<Nan::Persistent<v8::Object>> {{=p.name}}_;
 {{?}}
 {{~}}

--- a/templates/nanCxxImplProperty.def
+++ b/templates/nanCxxImplProperty.def
@@ -66,9 +66,18 @@ NAN_GETTER({{=className}}::{{=p.name}}Getter) {
 {{?? isArray(p.idlType) }}
   info.GetReturnValue().Set(static_cast<v8::Local<v8::Array>>(impl_val));
 {{?? p.idlType.idlType === 'ArrayBuffer' }}
-  v8::Local<v8::Object> value;
-  if (Nan::NewBuffer(impl_val.data, impl_val.size).ToLocal(&value)) {
-    info.GetReturnValue().Set(value);
+  if (! {{=myself}}{{=p.name}}_) {
+    v8::Local<v8::Object> value;
+    if(Nan::NewBuffer(impl_val.data, impl_val.size).ToLocal(&value)) {
+      {{=myself}}{{=p.name}}_.reset(new Nan::Persistent<v8::Object>(value));
+    }
+  }
+
+  if ({{=myself}}{{=p.name}}_) {
+    v8::Local<v8::Object> obj = Nan::New(*{{=myself}}{{=p.name}}_);
+    info.GetReturnValue().Set(obj);
+  } else {
+    info.GetReturnValue().Set(Nan::Undefined());
   }
 {{?? true}}
   info.GetReturnValue().Set(Nan::New(impl_val){{=str}});

--- a/templates/nanCxxImplPropertyVarsRelease.def
+++ b/templates/nanCxxImplPropertyVarsRelease.def
@@ -2,7 +2,7 @@
 {{#def.members}}
 
 {{~ getNonStaticPropertyMembers(it) :p:i }}
-{{? isInterface(p.idlType, it.refTypeMap) }}
+{{? isInterface(p.idlType, it.refTypeMap) || (p.idlType.idlType === 'ArrayBuffer')}}
   {{=p.name}}_.reset();
 {{?}}
 {{~}}


### PR DESCRIPTION
@kenny-y Please help to review this bug fix. thanks.

Each ArrayBuffer property access will generate a v8 object but with the same internal buffer.
As the v8 object owns the buffer, when garbage collection is triggered, the internal buffer will be freed multiple times. It's better that each access of the ArrayBuffer property doesn't create new objects. 