### PR TITLE
Fix #76 and change StopThread to return promise

### DIFF
--- a/templates/helperHeaderPromise.dot
+++ b/templates/helperHeaderPromise.dot
@@ -69,7 +69,7 @@ class PromiseHelper {
   }
 
   bool IsPromiseCreated() {
-    return js_resolver_.IsEmpty();
+    return !js_resolver_.IsEmpty();
   }
 
  private:

--- a/templates/helperHeaderThreadEvent.dot
+++ b/templates/helperHeaderThreadEvent.dot
@@ -27,7 +27,7 @@ class ThreadEventHelper {
   v8::Local<v8::Promise> StartThread();
   void PauseThread();
   void ResumeThread();
-  void StopThread();
+  v8::Local<v8::Promise> StopThread();
 
  protected:
   class EventEmitter {
@@ -67,9 +67,12 @@ class ThreadEventHelper {
   inline PromiseHelper& GetThreadStartPromiseHelper() {
     return thread_start_promise_;
   }
-
+  inline PromiseHelper& GetThreadStopPromiseHelper() {
+    return thread_stop_promise_;
+  }
  private:
   PromiseHelper thread_start_promise_;
+  PromiseHelper thread_stop_promise_;
 
   bool thread_cont_working_;
   Nan::Persistent<v8::Object> js_this_;
@@ -81,6 +84,7 @@ class ThreadEventHelper {
   bool thread_singleloop_flag_;
   bool thread_started_flag_;
   bool thread_failed_flag_;
+  bool thread_stopped_flag_;
 };
 
 #endif  // _THREAD_EVENT_HELPER_H_

--- a/templates/helperHeaderThreadEventCpp.dot
+++ b/templates/helperHeaderThreadEventCpp.dot
@@ -13,6 +13,7 @@ void ThreadEventHelper::Reset() {
   thread_cont_working_ = true;
   thread_started_flag_ = false;
   thread_failed_flag_ = false;
+  thread_stopped_flag_ = false;
 }
 
 v8::Local<v8::Promise> ThreadEventHelper::StartThread() {
@@ -31,12 +32,10 @@ void ThreadEventHelper::ResumeThread() {
   // TODO(widl-nan): resume thread
 }
 
-void ThreadEventHelper::StopThread() {
+v8::Local<v8::Promise> ThreadEventHelper::StopThread() {
   thread_cont_working_ = false;
-  uv_thread_join(&thread_);
-  uv_close(reinterpret_cast<uv_handle_t*>(&async_), NULL);
-  ResetJavaScriptThis();
-  Reset();
+  auto promise = GetThreadStopPromiseHelper().CreatePromise();
+  return promise;
 }
 
 void ThreadEventHelper::AsyncProc(uv_async_t *handle) {
@@ -58,6 +57,15 @@ void ThreadEventHelper::AsyncProc(uv_async_t *handle) {
   if (me->thread_singleloop_flag_) {
     me->thread_singleloop_flag_ = false;
     me->OnSingleLoopFinished(EventEmitter(&me->js_this_));
+  }
+
+  if(me->thread_stopped_flag_) {
+    uv_close(reinterpret_cast<uv_handle_t*>(&me->async_), NULL);
+    me->ResetJavaScriptThis();
+    me->Reset();
+   if(me->GetThreadStopPromiseHelper().IsPromiseCreated()) {
+      me->GetThreadStopPromiseHelper().ResolvePromise();
+    }
   }
 }
 
@@ -99,6 +107,7 @@ void ThreadEventHelper::ThreadProc(void* arg) {
     me->thread_failed_flag_ = true;
     uv_async_send(&me->async_);
   }
-
+  me->thread_stopped_flag_ = true;
+  uv_async_send(&me->async_);
   me->ThreadCleaner();
 }

--- a/test/event-emitter/meal.cpp
+++ b/test/event-emitter/meal.cpp
@@ -19,7 +19,7 @@ bool CookHelper::ThreadStarter() {
 }
 
 // Running in worker thread, to deal with the pipeline loop
-bool CookHelper::ThreadWorker(long long numOfLoops) {
+bool CookHelper::ThreadWorker(long long numOfLoops) { //NOLINT
   std::stringstream ss;
   ss << "loop: #" << numOfLoops;
   state_ = ss.str();
@@ -56,4 +56,8 @@ void Meal::initialize() {
 
 v8::Handle<v8::Promise> Meal::cook(const std::string& chefName) {
   return helper_->StartThread();
+}
+
+v8::Handle<v8::Promise> Meal::stop() {
+  return helper_->StopThread();
 }

--- a/test/event-emitter/meal.h
+++ b/test/event-emitter/meal.h
@@ -22,7 +22,7 @@ class CookHelper : public ThreadEventHelper {
   bool ThreadStarter() override;
   // Running in worker thread, to deal with the pipeline loop
   // Return true to continue loop
-  bool ThreadWorker(long long numOfLoops) override;
+  bool ThreadWorker(long long numOfLoops) override; //NOLINT
   // Running in worker thread, to clean things up
   void ThreadCleaner() override;
   // Running in main thread
@@ -45,6 +45,8 @@ class Meal {
   void initialize();
 
   v8::Handle<v8::Promise> cook(const std::string& chefName);
+
+  v8::Handle<v8::Promise> stop();
 
   void SetJavaScriptThis(v8::Local<v8::Object> JavaScriptThis) {
     helper_->SetJavaScriptThis(JavaScriptThis);

--- a/test/event-emitter/promise.widl
+++ b/test/event-emitter/promise.widl
@@ -12,5 +12,5 @@ interface Meal {
   void initialize();
 
   Promise<String> cook(String chefName);
-
+  Promise<void> stop();
 };

--- a/test/test-event-emitter.js
+++ b/test/test-event-emitter.js
@@ -63,6 +63,19 @@ describe('widl-nan Unit Test - IDL EventEmitter', function() {
     });
   });
 
+  it('Return type of stop() is a Promise', done => {
+    var x = new Meal();
+    x.initialize('rice', 0.5);
+    x.cook('tim');
+    return new Promise((resolve, reject) => {
+      x.stop().then(() => {
+        resolve();
+      }).catch(e => {
+        reject(e);
+      });
+    });
+  });
+
   it('Event can be emitted', () => {
     var x = new Meal();
     x.initialize('rice', 0.5);


### PR DESCRIPTION
1. The IsPromiseCreated method of PromiseHelper should return reverted
value.
2. Change the StopThread method of ThreadEventHelper to return promise.

Fixes #76 

@kenny-y PTAL, though this worker is not needed in future, currently, PT relies on it to stop, so I updated it, and also fixed a bug #76. Thanks.