### PR TITLE
Force to run microtasks after resolve thread helper promises

### DIFF
--- a/templates/helperHeaderThreadEventCpp.dot
+++ b/templates/helperHeaderThreadEventCpp.dot
@@ -46,12 +46,16 @@ void ThreadEventHelper::AsyncProc(uv_async_t *handle) {
   if (me->thread_started_flag_) {
     me->thread_started_flag_ = false;
     me->GetThreadStartPromiseHelper().ResolvePromise();
+    // Workaround for forcing the promise to be actually resolved.
+    v8::Isolate::GetCurrent()->RunMicrotasks();
   }
 
   if (me->thread_failed_flag_) {
     me->thread_failed_flag_ = false;
     auto msg = std::string("Worker thread fail");
     me->GetThreadStartPromiseHelper().RejectPromise(msg);
+    // Workaround for forcing the promise to be actually rejectd.
+    v8::Isolate::GetCurrent()->RunMicrotasks();
   }
 
   if (me->thread_singleloop_flag_) {
@@ -65,6 +69,8 @@ void ThreadEventHelper::AsyncProc(uv_async_t *handle) {
     me->Reset();
    if(me->GetThreadStopPromiseHelper().IsPromiseCreated()) {
       me->GetThreadStopPromiseHelper().ResolvePromise();
+      // Workaround for forcing the promise to be actually resolved.
+      v8::Isolate::GetCurrent()->RunMicrotasks();
     }
   }
 }

--- a/test/test-event-emitter.js
+++ b/test/test-event-emitter.js
@@ -70,6 +70,7 @@ describe('widl-nan Unit Test - IDL EventEmitter', function() {
     return new Promise((resolve, reject) => {
       x.stop().then(() => {
         resolve();
+        done();
       }).catch(e => {
         reject(e);
       });


### PR DESCRIPTION
This is a workaround to force the promise resolving and rejecting
work to be done immediatelly. Also update test for thread helper's
stop() testing. The already existing testcase covers the start, stop
of the thread, so no new case is added.

@kenny-y PTAL, thanks.
