### PR TITLE
Check the empty before dereference the pointer

### DIFF
--- a/templates/nanCxxImplPropertyVarsRelease.def
+++ b/templates/nanCxxImplPropertyVarsRelease.def
@@ -3,7 +3,8 @@
 
 {{~ getNonStaticPropertyMembers(it) :p:i }}
 {{? isInterface(p.idlType, it.refTypeMap) || (p.idlType.idlType === 'ArrayBuffer')}}
-  {{=p.name}}_->Reset(); // Explicitly reset persistent reference, dtor won't always do Reset()
+  if ({{=p.name}}_)
+    {{=p.name}}_->Reset(); // Explicitly reset persistent reference, dtor won't always do Reset()
   {{=p.name}}_.reset(); // Destroy persistent object
 {{?}}
 {{~}}


### PR DESCRIPTION
This may cause crash if the pointer is empty.

Fixes #105 

@kenny-y PTAL, thanks.