### PR TITLE
Return undefined if impl method return nullptr

### DIFF
--- a/templates/nanCxxImplMethod.def
+++ b/templates/nanCxxImplMethod.def
@@ -136,9 +136,13 @@ var argStr = args.join(', ');
     // Return type is an interface object
     auto implObj = {{=functionCallPrefix}}{{=methodName}}({{=argStr}});
 {{ var retType = method.idlType.idlType; }}
-    auto value = Nan{{=retType}}::NewInstance();
-    ObjectWrap::Unwrap<Nan{{=retType}}>(value)->Set{{=retType}}Impl(implObj);
-    info.GetReturnValue().Set(value);
+    if (!implObj) {
+      info.GetReturnValue().Set(Nan::Undefined());
+    } else {
+      auto value = Nan{{=retType}}::NewInstance();
+      ObjectWrap::Unwrap<Nan{{=retType}}>(value)->Set{{=retType}}Impl(implObj);
+      info.GetReturnValue().Set(value);
+    }
 {{?? isDictionary(method.idlType, it.refTypeMap)}}
     // Return type is a dictionary object
     auto value = {{=functionCallPrefix}}{{=methodName}}({{=argStr}});

--- a/test/interface/circle.cpp
+++ b/test/interface/circle.cpp
@@ -19,3 +19,7 @@ Point* Circle::triangulate(const Circle& c1,
   pt->set_y(18.75);
   return pt;
 }
+
+Point* Circle::emptyReturn() {
+  return nullptr;
+}

--- a/test/interface/circle.h
+++ b/test/interface/circle.h
@@ -44,6 +44,8 @@ class Circle {
 
   Point* triangulate(const Circle& c1, const Circle& c2, const Circle& c3);
 
+  Point* emptyReturn();
+
  private:
   float cx_;
   float cy_;

--- a/test/interface/return.widl
+++ b/test/interface/return.widl
@@ -18,4 +18,5 @@ interface Circle {
   attribute float radius;
 
   Point triangulate(Circle c1, Circle c2, Circle c3);
+  Point emptyReturn();
 };

--- a/test/test-interface.js
+++ b/test/test-interface.js
@@ -87,4 +87,11 @@ describe('widl-nan Unit Test - interface', function() {
     assert.equal(point.y, 18.75);   // Mock value, see circle.cpp
     done();
   });
+
+  it('Method returning undefined if impl method return nullptr', done => {
+    var c = new Circle();
+    var point = c.emptyReturn();
+    assert.equal(point, undefined); // Returned undefined
+    done();
+  });
 });


### PR DESCRIPTION
For method with interface return value, if the impl method
returns nullptr, the js shall return undefined to avoid crash.
If not, an valid js object wraping null impl object is returned
to js and accessing its properties causes crash.

Fixes #107 
@kenny-y PTAL when you have time. thanks.