### PR TITLE
Add facility method 'CheckType' for Dictionary element type checking

### DIFF
--- a/templates/dictionaryHeader.dot
+++ b/templates/dictionaryHeader.dot
@@ -4,6 +4,7 @@
 {{#def.dictionary}}
 {{#def.interface}}
 {{#def.enum}}
+{{#def.buildValidEnumValuesList}}
 
 {{
 var dictionaryClassName = it.name;
@@ -87,6 +88,82 @@ var requiredMembersStr = '{' + requiredMembers.join(', ') + '}';
     return true;
   }
 
+  bool CheckType(std::string* error) const {
+    if (!RequiredMemberCheck(v8obj_)) {
+      if (error)
+        *error = "{{=dictionaryClassName}} missing required member";
+      return false;
+    }
+{{~it.members :p:i}}
+{{
+var memberNameTmp = p.name;
+var memberTypeTmp = idlType2CxxType(p.idlType, it.refTypeMap);
+}}
+    if (IsMemberPresent("{{=memberNameTmp}}")) {
+      auto value = GetMember("{{=memberNameTmp}}");
+{{? p.type === 'field' && isBoolean(p.idlType) && !isArray(p.idlType) }}
+      if (!value->IsBoolean()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be a boolean";
+        return false;
+      }
+{{?? p.type === 'field' && isPrimitiveNumberType(p.idlType)}}
+      if (!value->IsNumber()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be Number";
+        return false;
+      }
+{{?? p.type === 'field' && isString(p.idlType) && !isArray(p.idlType) }}
+      if (!value->IsString()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be a string";
+        return false;
+      }
+{{?? p.type === 'field' && isArray(p.idlType) }}
+      if (!value->IsArray()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be an Array";
+        return false;
+      }
+{{?? p.type === 'field' && isInterface(p.idlType, it.refTypeMap)}}
+      if (!value->IsObject()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be an object";
+        return false;
+      }
+{{?? p.type === 'field' && (isDictionary(p.idlType, it.refTypeMap))}}
+{{var dictionaryTypeTmp = p.idlType.idlType;}}
+      if (!value->IsObject()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be an dictionary";
+        return false;
+      }
+      {{=dictionaryTypeTmp}} option_value = value->ToObject();
+      if (!option_value.CheckType(error))
+        return false;
+{{?? p.type === 'field' && (isEnumType(p.idlType, it.refTypeMap)) }}
+      if (!value->IsString()) {
+        if (error)
+          *error = "{{=memberNameTmp}} should be a valid enum string";
+        return false;
+      }
+{{
+var enumDefTmp = getEnumDef(p.idlType, it.refTypeMap);
+var enumNameTmp = enumDefTmp.name;
+}}
+      std::string string_value = EXTRACT_v8_string(value);
+      // Valid enum values for enum, original IDL type: {{=enumNameTmp}}
+      const char* VALID_ENUM_{{=(enumNameTmp.toUpperCase())}}_INFO[] = { {{=buildValidEnumValuesList(enumDefTmp)}} };
+      if (!IsEnumValueValid(string_value, VALID_ENUM_{{=(enumNameTmp.toUpperCase())}}_INFO)) {
+        if (error)
+          *error = "{{=memberNameTmp}} is not a valid enum value";
+        return false;
+      }
+{{?}}
+    }
+{{~}}
+    return true;
+  }
 
 {{~it.members :p:i}}
 

--- a/templates/idlType.def
+++ b/templates/idlType.def
@@ -23,6 +23,10 @@ var isPrimitiveType = function (idlType) {
       || type === 'String';
 };
 
+var isBoolean = function (idlType) {
+  return idlType.idlType === 'boolean';
+};
+
 var idlType2CxxType = function (idlType, refTypeMap) {
   var type = idlType.idlType;
   if (isArray(idlType)) {
@@ -74,6 +78,10 @@ var isString = function (idlType, refTypeMap) {
 
 var isNonStringPrimitiveType = function (idlType, refTypeMap) {
   return isPrimitiveType(idlType) && !isString(idlType);
+};
+
+var isPrimitiveNumberType = function (idlType, refTypeMap) {
+  return isPrimitiveType(idlType) && !isString(idlType) && !isBoolean(idlType);
 };
 
 var idlType2V8Type = function (idlType, refTypeMap, callback) {

--- a/test/dictionary/dictionary.widl
+++ b/test/dictionary/dictionary.widl
@@ -32,7 +32,8 @@ dictionary PolygonDrawOption {
 Constructor
 ]
 interface Painter {
-  void drawText(DOMString text, PaintOptions options);  
+  void drawText(DOMString text, PaintOptions options);
+  bool checkOptions(PaintOptions options);
   attribute PaintOptions options;
   PaintOptions getFactoryOptions();
 

--- a/test/dictionary/painter.cpp
+++ b/test/dictionary/painter.cpp
@@ -42,6 +42,10 @@ void Painter::drawText(const std::string& text, const PaintOptions& options) {
   switch_ = options.get_others().get_switch();
 }
 
+bool Painter::checkOptions(const PaintOptions& options) {
+  return options.CheckType(nullptr);
+}
+
 PaintOptions Painter::getFactoryOptions() {
   // Temp: just reusing options property
   return get_options();

--- a/test/dictionary/painter.h
+++ b/test/dictionary/painter.h
@@ -29,6 +29,8 @@ class Painter {
 
   void drawText(const std::string& text, const PaintOptions& options);
 
+  bool checkOptions(const PaintOptions& options);
+
   PaintOptions getFactoryOptions();
 
   void drawPolygon(const PolygonDrawOption& polygon);

--- a/test/test-dictionary.js
+++ b/test/test-dictionary.js
@@ -115,4 +115,25 @@ describe('widl-nan Unit Test - IDL dictionary', function() {
 
     done();
   });
+
+  it('Check PaintOptions element value type', done => {
+    var x = new Painter();
+    var validOption = {
+      offset: new Point(10, 20),
+      color: 'red',
+      flags: 1860,
+      others: {switch: true}
+    };
+    var invalidOption = {
+      offset: new Point(10, 20),
+      color: 123,
+      flags: 'flags',
+      others: {switch: true}
+    };
+    var isValid = x.checkOptions(validOption);
+    assert.equal(isValid, true);
+    isValid = x.checkOptions(invalidOption);
+    assert.equal(isValid, false);
+    done();
+  });
 });


### PR DESCRIPTION
This mainly covers type checking for Number, string, enum and supports
Dictionary elment recursion.

Fixes #109 

@kenny-y PTAL, thanks.